### PR TITLE
Show admin notice error when autoload.php file does not exist.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1766,16 +1766,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "30f38bffc6f24293dadd1823936372dfa9e86e2f"
+                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/30f38bffc6f24293dadd1823936372dfa9e86e2f",
-                "reference": "30f38bffc6f24293dadd1823936372dfa9e86e2f",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/a12f7e301eb7258bb68acd89d4aefa05c2906cae",
+                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae",
                 "shasum": ""
             },
             "require": {
@@ -1808,7 +1808,7 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2021-09-17T15:28:14+00:00"
+            "time": "2021-10-02T14:08:47+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -2795,6 +2795,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "abandoned": true,
             "time": "2015-07-28T20:34:47+00:00"
         },
         {
@@ -2890,16 +2891,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.0",
+            "version": "3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
                 "shasum": ""
             },
             "require": {
@@ -2937,7 +2938,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2021-04-09T00:54:41+00:00"
+            "time": "2021-10-11T04:00:11+00:00"
         },
         {
             "name": "symfony/finder",

--- a/http-requests-tracker.php
+++ b/http-requests-tracker.php
@@ -24,6 +24,34 @@ define( 'HRT_TEMPLATES', dirname( __FILE__ ) . '/templates' );
 define( 'HRT_LANGUAGES', dirname( __FILE__ ) . '/i18n/languages' );
 define( 'HRT_PLUGIN_REL_LANGUAGES_PATH', 'i18n/languages' );
 
+// Check for the existence of autoloader file.
+if ( ! file_exists( dirname( __FILE__ ) . '/vendor/autoload.php' ) ) {
+	add_action(
+		'admin_notices',
+		function() {
+			printf(
+				'<div class="notice notice-error is-dismissible"><p><strong>%s </strong>%s</p><button type="button" class="notice-dismiss"><span class="screen-reader-text">%s</span></button></div>',
+				esc_html( 'HTTP Requests Tracker:' ),
+				__( 'Requires autoloader files to work properly. Run <code>composer update</code> from the wp-content/plugins/http-requests-tracker directory.', 'hrt' ),
+				esc_html__( 'Dismiss this notice.', 'hrt' )
+			);
+		}
+	);
+
+	add_action(
+		'admin_init',
+		function() {
+			deactivate_plugins( plugin_basename( HRT_PLUGIN_FILE ) );
+
+			if ( isset( $_GET['activate'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				unset( $_GET['activate'] );
+			}
+		}
+	);
+
+	return;
+}
 /**
  * Include the autoloader.
  *
@@ -32,7 +60,7 @@ define( 'HRT_PLUGIN_REL_LANGUAGES_PATH', 'i18n/languages' );
 require_once dirname( __FILE__ ) . '/vendor/autoload.php';
 
 /**
- * Bootstrap the appplication.
+ * Bootstrap the application.
  *
  * @since 0.1.0
  */


### PR DESCRIPTION
Show admin notice and deactivate the plugin if the vendor.php file is absent.


### Screenshots :

* Before
![Screenshot-20211017111614-1915x594](https://user-images.githubusercontent.com/8264719/137613233-8823c035-e507-4a1e-bbf9-bf52d0617e9a.png)

* After
![Screenshot-20211017111557-1910x528](https://user-images.githubusercontent.com/8264719/137613237-0739e17d-6373-4220-9c0c-fb5e6717ff36.png)