### PR TITLE
Show admin notice error when assets folder does not exist.

### DIFF
--- a/http-requests-tracker.php
+++ b/http-requests-tracker.php
@@ -31,6 +31,35 @@ define( 'HRT_PLUGIN_REL_LANGUAGES_PATH', 'i18n/languages' );
  */
 require_once dirname( __FILE__ ) . '/vendor/autoload.php';
 
+// Check for the existence of assets folder.
+if ( ! file_exists( dirname( __FILE__ ) . '/assets/js/build/hrt-backend.js' ) ) {
+	add_action(
+		'admin_notices',
+		function() {
+			printf(
+				'<div class="notice notice-error is-dismissible"><p><strong>%s </strong>%s</p><button type="button" class="notice-dismiss"><span class="screen-reader-text">%s</span></button></div>',
+				esc_html( 'HTTP Requests Tracker:' ),
+				__( 'Assets are need to be built. Run <code>yarn && yarn build</code> from the wp-content/plugins/http-requests-tracker directory.', 'hrt' ),
+				esc_html__( 'Dismiss this notice.', 'hrt' )
+			);
+		}
+	);
+
+	add_action(
+		'admin_init',
+		function() {
+			deactivate_plugins( plugin_basename( HRT_PLUGIN_FILE ) );
+
+			if ( isset( $_GET['activate'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				unset( $_GET['activate'] );
+			}
+		}
+	);
+
+	return;
+}
+
 /**
  * Bootstrap the appplication.
  *


### PR DESCRIPTION
Show admin notice and deactivate the plugin if the assets folder is absent.

### Screenshots:

* Before
![Screenshot-20211017132334-1919x598](https://user-images.githubusercontent.com/8264719/137616931-d6fede16-57e5-4018-b2e7-6a017e7eb5b9.png)

* After
![Screenshot-20211017132027-1911x522](https://user-images.githubusercontent.com/8264719/137616943-faee57c9-34ec-48c6-9d9b-c039397e320f.png)

